### PR TITLE
Fix brops intermittent test failures 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,12 +11,12 @@
 
 {deps, [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.4"}}},
-  {poolboy, ".*", {git, "git://github.com/nhs-riak/poolboy.git", {branch, "rdb/0.8.1p3-nhs-2.2.5"}}},
-  {basho_stats, ".*", {git, "git://github.com/nhs-riak/basho_stats.git", {branch, "rdb/1.0.3-nhs-2.2.5"}}},
+  {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {branch, "develop-2.2.5"}}},
+  {basho_stats, ".*", {git, "git://github.com/nhs-riak/basho_stats.git", {branch, "master"}}},
   {riak_sysmon, ".*", {git, "https://github.com/basho/riak_sysmon.git", {tag, "2.1.5"}}},
-  {eleveldb, ".*", {git, "git://github.com/nhs-riak/eleveldb.git", {branch, "rdb/2.0.34-nhs-2.2.5"}}},
-  {riak_ensemble, ".*", {git, "https://github.com/nhs-riak/riak_ensemble", {branch, "rdb/2.1.8-nhs-2.2.5"}}},
-  {pbkdf2, ".*", {git, "git://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "rdb/2.0.0-nhs-2.2.5"}}},
-  {exometer_core, ".*", {git, "git://github.com/nhs-riak/exometer_core.git", {branch, "rdb/1.0.0-basho9-nhs-2.2.5"}}},
-  {clique, ".*", {git, "https://github.com/nhs-riak/clique.git", {branch, "rdb/0.3.9-nhs-2.2.5"}}}
+  {eleveldb, ".*", {git, "git://github.com/nhs-riak/eleveldb.git", {branch, "2.0"}}},
+  {riak_ensemble, ".*", {git, "https://github.com/nhs-riak/riak_ensemble", {branch, "develop-2.2"}}},
+  {pbkdf2, ".*", {git, "git://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "master"}}},
+  {exometer_core, ".*", {git, "git://github.com/nhs-riak/exometer_core.git", {branch, "master"}}},
+  {clique, ".*", {git, "https://github.com/nhs-riak/clique.git", {branch, "master"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,12 +11,12 @@
 
 {deps, [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.4"}}},
-  {poolboy, ".*", {git, "git://github.com/basho/poolboy.git", {tag, "0.8.1p3"}}},
-  {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", {tag, "1.0.3"}}},
+  {poolboy, ".*", {git, "git://github.com/nhs-riak/poolboy.git", {branch, "rdb/0.8.1p3-nhs-2.2.5"}}},
+  {basho_stats, ".*", {git, "git://github.com/nhs-riak/basho_stats.git", {branch, "rdb/1.0.3-nhs-2.2.5"}}},
   {riak_sysmon, ".*", {git, "https://github.com/basho/riak_sysmon.git", {tag, "2.1.5"}}},
   {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.34"}}},
   {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {tag, "2.1.8"}}},
-  {pbkdf2, ".*", {git, "git://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}},
-  {exometer_core, ".*", {git, "git://github.com/basho/exometer_core.git", {tag, "1.0.0-basho9"}}},
+  {pbkdf2, ".*", {git, "git://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "rdb/2.0.0-nhs-2.2.5"}}},
+  {exometer_core, ".*", {git, "git://github.com/nhs-riak/exometer_core.git", {branch, "rdb/1.0.0-basho9-nhs-2.2.5"}}},
   {clique, ".*", {git, "https://github.com/basho/clique.git", {tag, "0.3.9"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
   {riak_ensemble, ".*", {git, "https://github.com/basho/riak_ensemble", {tag, "2.1.8"}}},
   {pbkdf2, ".*", {git, "git://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "rdb/2.0.0-nhs-2.2.5"}}},
   {exometer_core, ".*", {git, "git://github.com/nhs-riak/exometer_core.git", {branch, "rdb/1.0.0-basho9-nhs-2.2.5"}}},
-  {clique, ".*", {git, "https://github.com/basho/clique.git", {tag, "0.3.9"}}}
+  {clique, ".*", {git, "https://github.com/nhs-riak/clique.git", {branch, "rdb/0.3.9-nhs-2.2.5"}}}
 ]}.

--- a/test/bprops_eqc.erl
+++ b/test/bprops_eqc.erl
@@ -307,15 +307,17 @@ stop_pid(Tag, Pid) ->
     exit(Pid, shutdown),
     ok = wait_for_pid(Tag, Pid).
 
-wait_for_pid(_Tag, Pid) ->
+wait_for_pid(Tag, Pid) ->
     Mref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Mref, process, _, _} ->
             ok
     after
-        10000 ->
+        5000 ->
+            demonitor(Mref, [flush]),
 	    exit(Pid, kill),
-	    ok
+	    wait_for_pid(Tag, Pid)
+
     end.
 
 -endif.

--- a/test/bprops_eqc.erl
+++ b/test/bprops_eqc.erl
@@ -247,8 +247,8 @@ prop_buckets() ->
                         application:set_env(riak_core, metadata_hashtree_timer, 4294967295),
                         application:set_env(riak_core, default_bucket_props, ?DEFAULT_BPROPS),
                         application:set_env(riak_core, cluster_name, "riak_core_bucket_eqc"),
-                        stop_pid(whereis(riak_core_ring_events)),
-                        stop_pid(whereis(riak_core_ring_manager)),
+                        stop_pid(riak_core_ring_events, whereis(riak_core_ring_events)),
+                        stop_pid(riak_core_ring_manager, whereis(riak_core_ring_manager)),
                         {ok, RingEvents} = riak_core_ring_events:start_link(),
                         {ok, _RingMgr} = riak_core_ring_manager:start_link(test),
                         {ok, Claimant} = riak_core_claimant:start_link(),
@@ -261,12 +261,12 @@ prop_buckets() ->
                         %%
                         %% shut down
                         %%
-                        stop_pid(Broadcast),
-                        stop_pid(Hashtree),
-                        stop_pid(MetaMgr),
-                        stop_pid(Claimant),
+                        stop_pid(riak_core_broadcast, Broadcast),
+                        stop_pid(riak_core_metadata_hashtree, Hashtree),
+                        stop_pid(riak_core_metadata_manager, MetaMgr),
+                        stop_pid(riak_core_claimant, Claimant),
                         riak_core_ring_manager:stop(),
-                        stop_pid(RingEvents),
+                        stop_pid(riak_core_ring_events2, RingEvents),
 
                         eqc_statem:pretty_commands(
                             ?MODULE, Cmds,
@@ -300,21 +300,21 @@ setup_cleanup() ->
 %% internal helper functions
 %%
 
-stop_pid(Other) when not is_pid(Other) ->
+stop_pid(_Tag, Other) when not is_pid(Other) ->
     ok;
-stop_pid(Pid) ->
+stop_pid(Tag, Pid) ->
     unlink(Pid),
     exit(Pid, shutdown),
-    ok = wait_for_pid(Pid).
+    ok = wait_for_pid(Tag, Pid).
 
-wait_for_pid(Pid) ->
+wait_for_pid(Tag, Pid) ->
     Mref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Mref, process, _, _} ->
             ok
     after
         5000 ->
-            {error, didnotexit}
+            {error, Tag, didnotexit}
     end.
 
 -endif.

--- a/test/bprops_eqc.erl
+++ b/test/bprops_eqc.erl
@@ -307,7 +307,7 @@ stop_pid(Tag, Pid) ->
     exit(Pid, shutdown),
     ok = wait_for_pid(Tag, Pid).
 
-wait_for_pid(Tag, Pid) ->
+wait_for_pid(_Tag, Pid) ->
     Mref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Mref, process, _, _} ->

--- a/test/bprops_eqc.erl
+++ b/test/bprops_eqc.erl
@@ -313,8 +313,9 @@ wait_for_pid(Tag, Pid) ->
         {'DOWN', Mref, process, _, _} ->
             ok
     after
-        5000 ->
-            {error, Tag, didnotexit}
+        10000 ->
+	    exit(Pid, kill),
+	    ok
     end.
 
 -endif.


### PR DESCRIPTION
All around Pid start/registration/stop behaviour in bprops_eqc test. The deps stuff will need updating again when PRs merged that take us off tags and back onto branches for this dev cycle