### PR TITLE
Move `node_confirms` to version specific props

### DIFF
--- a/src/riak_core_bucket_type.erl
+++ b/src/riak_core_bucket_type.erl
@@ -120,26 +120,31 @@
 %% @doc The hardcoded defaults for all bucket types.
 -spec defaults() -> bucket_type_props().
 defaults() ->
-    custom_type_defaults().
+    v225_defaults() ++ custom_type_defaults().
+
+%% @private default propeties added for v2.2.5
+-spec v225_defaults() -> bucket_type_props().
+v225_defaults() ->
+    [{node_confirms, 0}].
 
 %% @doc The hardcoded defaults for the legacy, default bucket
 %% type. These find their way into the `default_bucket_props'
 %% environment variable
 -spec defaults(default_type) -> bucket_type_props().
 defaults(default_type) ->
-    default_type_defaults().
+    v225_defaults() ++ default_type_defaults().
 
 default_type_defaults() ->
-    common_defaults() ++
-        [{dvv_enabled, false},
-         {allow_mult, false}].
+    [{dvv_enabled, false},
+     {allow_mult, false}] ++
+        common_defaults().
 
 custom_type_defaults() ->
-    common_defaults() ++
-        %% @HACK dvv is a riak_kv only thing, yet there is nowhere else
-        %% to put it (except maybe fixups?)
-        [{dvv_enabled, true},
-         {allow_mult, true}].
+    %% @HACK dvv is a riak_kv only thing, yet there is nowhere else
+    %% to put it (except maybe fixups?)
+    [{dvv_enabled, true},
+     {allow_mult, true}] ++
+        common_defaults().
 
 common_defaults() ->
     [{linkfun, {modfun, riak_kv_wm_link_walker, mapreduce_linkfun}},
@@ -151,7 +156,6 @@ common_defaults() ->
      {r, quorum},
      {w, quorum},
      {pw, 0},
-     {node_confirms, 0},
      {dw, quorum},
      {rw, quorum},
      {basic_quorum, false},


### PR DESCRIPTION
See bug report nhs-riak/riak_kv#9. This commit moves the node_confirms
property into a version specific list/function. It changes the list
concatenation to be shortest list as the left-hand-operand (erlang docs
say this is faster
http://erlang.org/doc/efficiency_guide/listHandling.html). Why not,
since I was in here futzing around.

NOTE: I kept with the existing `defaults/0` and `defaults/1` rather than
the discussed "new_defaults" or "post_transition_defaults" as I was
unclear where, if anywhere, `defaults/1` was called. `defaults/0` is
implicitly "post-transition defaults" already.